### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,30 +122,30 @@ TeamLeader::setRefreshToken($refresh_token);
 TeamLeader::setExpiresAt($expired_at);
 TeamLeader::checkAndDoRefresh();
 
-TeamLeader::crm()->contact()->list(['filter' => ..., 'page' => ..., 'sort' => ...]); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.list
-TeamLeader::crm()->contact()->info($id); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.info
-TeamLeader::crm()->contact()->add(['first_name' => ..., ...]); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.add
-TeamLeader::crm()->contact()->update($id, ['first_name' => ...]) //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.update
-TeamLeader::crm()->contact()->delete($id); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.delete
-TeamLeader::crm()->contact()->tag($id, $tags); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.tag
-TeamLeader::crm()->contact()->untag($id, $tags); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.untag
-TeamLeader::crm()->contact()->linkToCompany($id, $companyId, $position, $decisionMaker) //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.linktocompany
-TeamLeader::crm()->contact()->unlinkToCompany($id, $companyId); //https://developer.teamleader.eu/#/reference/crm/contacts/contacts.unlinkfromcompany
+TeamLeader::crm()->contact()->list(['filter' => ..., 'page' => ..., 'sort' => ...]); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.list
+TeamLeader::crm()->contact()->info($id); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.info
+TeamLeader::crm()->contact()->add(['first_name' => ..., ...]); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.add
+TeamLeader::crm()->contact()->update($id, ['first_name' => ...]) //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.update
+TeamLeader::crm()->contact()->delete($id); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.delete
+TeamLeader::crm()->contact()->tag($id, $tags); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.tag
+TeamLeader::crm()->contact()->untag($id, $tags); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.untag
+TeamLeader::crm()->contact()->linkToCompany($id, $companyId, $position, $decisionMaker) //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.linktocompany
+TeamLeader::crm()->contact()->unlinkToCompany($id, $companyId); //https://developer.focus.teamleader.eu/#/reference/crm/contacts/contacts.unlinkfromcompany
 
-TeamLeader::deals()->list($data = []); //https://developer.teamleader.eu/#/reference/deals/deals/deals.list
-TeamLeader::deals()->info($id); //https://developer.teamleader.eu/#/reference/deals/deals/deals.info
-TeamLeader::deals()->create($data); //https://developer.teamleader.eu/#/reference/deals/deals/deals.create
-TeamLeader::deals()->update($id, $data); //https://developer.teamleader.eu/#/reference/deals/deals/deals.update
-TeamLeader::deals()->move($id, $phaseId); //https://developer.teamleader.eu/#/reference/deals/deals/deals.move
-TeamLeader::deals()->win($id); //https://developer.teamleader.eu/#/reference/deals/deals/deals.win
-TeamLeader::deals()->lose($id, $reason_id = null, $extra_info = null); //https://developer.teamleader.eu/#/reference/deals/deals/deals.lose
-TeamLeader::deals()->delete($id); //https://developer.teamleader.eu/#/reference/deals/deals/deals.delete
-TeamLeader::deals()->lostReasons($data = []); //https://developer.teamleader.eu/#/reference/deals/deals/lostreasons.list
+TeamLeader::deals()->list($data = []); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.list
+TeamLeader::deals()->info($id); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.info
+TeamLeader::deals()->create($data); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.create
+TeamLeader::deals()->update($id, $data); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.update
+TeamLeader::deals()->move($id, $phaseId); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.move
+TeamLeader::deals()->win($id); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.win
+TeamLeader::deals()->lose($id, $reason_id = null, $extra_info = null); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.lose
+TeamLeader::deals()->delete($id); //https://developer.focus.teamleader.eu/#/reference/deals/deals/deals.delete
+TeamLeader::deals()->lostReasons($data = []); //https://developer.focus.teamleader.eu/#/reference/deals/deals/lostreasons.list
 
 
-TeamLeader::webhooks()->list(); //https://developer.teamleader.eu/#/reference/other/webhooks/webhooks.list
-TeamLeader::webhooks()->register($data); //https://developer.teamleader.eu/#/reference/other/webhooks/webhooks.register
-TeamLeader::webhooks()->unregister($url, $types); //https://developer.teamleader.eu/#/reference/other/webhooks/webhooks.unregister
+TeamLeader::webhooks()->list(); //https://developer.focus.teamleader.eu/#/reference/other/webhooks/webhooks.list
+TeamLeader::webhooks()->register($data); //https://developer.focus.teamleader.eu/#/reference/other/webhooks/webhooks.register
+TeamLeader::webhooks()->unregister($url, $types); //https://developer.focus.teamleader.eu/#/reference/other/webhooks/webhooks.unregister
 ```
 
 The complete documentation can be found at: [http://www.madeit.be/](http://www.madeit.be/)

--- a/src/TeamLeader.php
+++ b/src/TeamLeader.php
@@ -24,8 +24,8 @@ class TeamLeader
 {
     protected $version = '1.0.0';
     protected $apiVersion = '1.0';
-    private $apiServer = 'https://api.teamleader.eu';
-    private $authServer = 'https://app.teamleader.eu';
+    private $apiServer = 'https://api.focus.teamleader.eu';
+    private $authServer = 'https://focus.teamleader.eu';
     private $clientId;
     private $clientSecret;
     private $accessToken;

--- a/src/config/teamleader.php
+++ b/src/config/teamleader.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'api_url'       => env('TEAMLEADER_API_URL', 'https://api.teamleader.eu'),
-    'auth_url'      => env('TEAMLEADER_AUTH_URL', 'https://app.teamleader.eu'),
+    'api_url'       => env('TEAMLEADER_API_URL', 'https://api.focus.teamleader.eu'),
+    'auth_url'      => env('TEAMLEADER_AUTH_URL', 'https://focus.teamleader.eu'),
     'client_id'     => env('TEAMLEADER_ID'),
     'client_secret' => env('TEAMLEADER_SECRET'),
     'redirect_uri'  => env('TEAMLEADER_REDIRECT'),

--- a/tests/TeamLeaderTest.php
+++ b/tests/TeamLeaderTest.php
@@ -21,7 +21,7 @@ class TeamLeaderTest extends TestCase
             ],
             'verify' => true,
         ]);
-        $teamleader = new TeamLeader('http://localhost', 'https://app.teamleader.eu', 'client_id', 'client_secret', 'http://localhost', $client);
+        $teamleader = new TeamLeader('http://localhost', 'https://focus.teamleader.eu', 'client_id', 'client_secret', 'http://localhost', $client);
 
         $this->assertEquals('client_id', $teamleader->getClientId());
         $this->assertEquals('client_secret', $teamleader->getClientSecret());


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.