### PR TITLE
send body data with a get request for filtering and paging

### DIFF
--- a/src/TeamLeader.php
+++ b/src/TeamLeader.php
@@ -218,7 +218,7 @@ class TeamLeader
         return $this->call('POST', $endPoint, $data);
     }
 
-    public function getCall($endPoint, $data)
+    public function getCall($endPoint, $data = null)
     {
         return $this->call('GET', $endPoint, $data);
     }

--- a/src/TeamLeader.php
+++ b/src/TeamLeader.php
@@ -218,9 +218,9 @@ class TeamLeader
         return $this->call('POST', $endPoint, $data);
     }
 
-    public function getCall($endPoint)
+    public function getCall($endPoint, $data)
     {
-        return $this->call('GET', $endPoint);
+        return $this->call('GET', $endPoint, $data);
     }
 
     public function putCall($endPoint, $data)


### PR DESCRIPTION
For example, deals.list supports filtering and paging. 
However the data (2nd attribute) is not parsed to the call:

 /Deals/Deal.php

```
/**
     * Get a list of deals.
     */
    public function list($data = [])
    {
        return $this->teamleader->getCall('deals.list', [
            'body' => json_encode($data),
        ]);
    }
```
